### PR TITLE
fix: app distribution params

### DIFF
--- a/.github/actions/distribute-apk/action.yml
+++ b/.github/actions/distribute-apk/action.yml
@@ -15,5 +15,5 @@ runs:
   using: "composite"
   steps:
     - name: App distribution upload
-      run: ./gradlew appDistributionUpload${{ inputs.BUILD_VARIANT }} --groups=${{ inputs.TESTER_GROUPS }} --releaseNotes=${{ inputs.RELEASE_NOTES }}
+      run: ./gradlew appDistributionUpload${{ inputs.BUILD_VARIANT }} --groups="${{ inputs.TESTER_GROUPS }}" --releaseNotes="${{ inputs.RELEASE_NOTES }}"
       shell: bash

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,7 @@ on:
       TESTER_GROUPS:
         description: 'Groups for testing separated by a comma'
         required: true
-        default: 'android-developers'
+        default: "${{ vars.FAD_TESTER_GROUPS }}"
         type: string
       RELEASE_NOTES:
         description: 'Describes the content of this version'

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -34,5 +34,5 @@ jobs:
         uses: ./.github/actions/distribute-apk
         with:
           BUILD_VARIANT: 'Release'
-          TESTER_GROUPS: 'android-developers'
+          TESTER_GROUPS: "${{ vars.FAD_TESTER_GROUPS }}"
           RELEASE_NOTES: 'Weekly build'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,8 +52,8 @@ android {
             signingConfig = signingConfigs.getByName("release")
             firebaseAppDistribution {
                 artifactType = "APK"
-                groups = "android-developers"
                 serviceCredentialsFile = "api-secrets/app-distribution/services_account_key.json"
+                // groups, testers and releaseNotes SHOULD be added on gradle command execution
             }
         }
         debug {


### PR DESCRIPTION
## Fix
Values for `releaseNotes` and `groups` are handled as string.