### PR TITLE
WL 6: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,104 @@
+name: 🐞 Bug report
+description: File a bug/issue
+title: "[BUG] <title>"
+labels: [ "bug" ]
+assignees:
+  - pereyrarg11
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        Please provide us your environment details!
+  - type: dropdown
+    id: app_version
+    attributes:
+      label: App version
+      description: What version of our app are you running?
+      options:
+        - 1.0.0
+        - Not listed here
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: sdk_version
+    attributes:
+      label: Android version
+      description: What Android version (API level) do you have?
+      options:
+        - Android 5.0 (API level 21)
+        - Android 5.1 (API level 22)
+        - Android 6 (API level 23)
+        - Android 7.0 (API level 24)
+        - Android 7.1 (API level 25)
+        - Android 8.0 (API level 26)
+        - Android 8.1 (API level 27)
+        - Android 9 (API level 28)
+        - Android 10 (API level 29)
+        - Android 11 (API level 30)
+        - Android 12 (API level 31)
+        - Android 12L (API level 32)
+        - Android 13 (API level 33)
+        - Android 14 (API level 34)
+        - Not listed here
+      default: 0
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Describe the behavior in order to understand what is happening
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Open the app and navigate to...
+        2. Scroll to...
+        3. Click on...
+    validations:
+      required: true
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,28 @@
+name: 🚀 Feature request
+description: Suggest an idea
+title: "[FEATURE] <title>"
+labels: [ "enhancement" ]
+assignees:
+  - pereyrarg11
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Brief explanation of the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: example
+    attributes:
+      label: Basic example
+      description: Describe a basic example; attach screenshots or links here.
+    validations:
+      required: false
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why are we doing this? What use cases does it support? What is the expected outcome?
+    validations:
+      required: false

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -34,5 +34,5 @@ jobs:
         uses: ./.github/actions/distribute-apk
         with:
           BUILD_VARIANT: 'Release'
-          TESTER_GROUPS: 'android-developers'
+          TESTER_GROUPS: 'android-developers,public-demo'
           RELEASE_NOTES: 'Weekly build'

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
     <br />
     <a href="https://appdistribution.firebase.dev/i/ac57e55786da5ad1">View Demo</a>
     ·
-    <a href="https://github.com/pereyrarg11/White-Label/issues/new">Report Bug</a>
+    <a href="https://github.com/pereyrarg11/White-Label/issues/new?assignees=pereyrarg11&labels=bug&projects=&template=bug_report.yaml&title=%5BBUG%5D+<title>">Report Bug</a>
     ·
-    <a href="https://github.com/pereyrarg11/White-Label/issues/new">Request Feature</a>
+    <a href="https://github.com/pereyrarg11/White-Label/issues/new?assignees=pereyrarg11&labels=enhancement&projects=&template=feature_request.yaml&title=%5BFEATURE%5D+<title>">Request Feature</a>
   </p>
 </div>
 
@@ -84,7 +84,7 @@ Contributions are what make the open source community such an amazing place to l
 and create. Any contributions you make are **greatly appreciated**.
 
 If you have a suggestion that would make this better, please fork the repo and create a pull request.
-You can also simply open a [Feature request](https://github.com/pereyrarg11/White-Label/issues/new).
+You can also simply open a [Feature request](https://github.com/pereyrarg11/White-Label/issues/new?assignees=pereyrarg11&labels=enhancement&projects=&template=feature_request.yaml&title=%5BFEATURE%5D+<title>).
 Don't forget to give the project a star! Thanks again!
 
 1. Fork the Project


### PR DESCRIPTION
## Chore
Issue templates were added. Links to them were updated in README.md
The tester-group `public-demo` was added on weekly build workflow.